### PR TITLE
[UI] Don't run Flask in debug mode in Docker

### DIFF
--- a/pyheap-ui/Dockerfile
+++ b/pyheap-ui/Dockerfile
@@ -14,6 +14,7 @@ EXPOSE 5000
 
 ENV FLASK_SERVER_NAME=0.0.0.0
 ENV PYTHONPATH=/pyheap
+ENV FLASK_DEBUG=false
 WORKDIR /pyheap-workdir
 ENTRYPOINT ["python3", "-m", "ui", "--file"]
 CMD []


### PR DESCRIPTION
One downside of running in the debug mode is double start, that is double loading of the heap.

Closes #78